### PR TITLE
🪶  Add chapter about planning implementations

### DIFF
--- a/docs/book/anatomy-of-a-code-change/change-decision.md
+++ b/docs/book/anatomy-of-a-code-change/change-decision.md
@@ -1,11 +1,21 @@
-Product - Feature
-Values, roadmap, strategie for market
+# Feature decisions
 
-Management - Split and milestones
-Continous integration strategies of milestones and sprints
+## Documenting decisions
 
-Engineer - Details, libraries, implementation
-Implementation details, algorithms, open source libraries vs building
+Decision making is always speculative. Even with lots of data to rely on, we are predicting the future.
+
+https://www.redhat.com/architect/architecture-decision-records
+
+Decision Records
+
+Number
+Date
+People involved
+Title
+Context
+Decision
+Status
+Consequences
 
 Make a decision and document it. Easier for people to accept a conscious decision if the decision making process is available.
 Document the outcome of a decision, to track successful and unsuccessful patterns.
@@ -13,3 +23,34 @@ Document the outcome of a decision, to track successful and unsuccessful pattern
 Document, review, and iterate to ensure every participant understands the same thing. Take notes during meetings and share them with everybody to avoid misunderstandings.
 
 Keep all of the above decisions and progress visible and public to all stakeholders. Update continously. Maybe tooling that accumulates PR, issue comments, documentation, kanban boards, design docs etc.
+
+The more context we are able to give, the more transparent our decision is communicated. When evaluating the use of different libraries add the name and version of the libraries, benchmark numbers, ease of implementation, licensing, projected maintenance work etc.
+
+We clearly define the evaluation process that led to our final decision with all aspects. Every decision has advantages and drawbacks which need to be documented and unambiguously weighed against each other.
+
+Parameters change over time and decisions will be reevaluated.
+
+
+## Process within a code change
+
+product roadmap
+design docs
+PR reference
+
+After product features have been milled into sprint tasks and the tasks assigned to respective teams and engineers we start planning our implementation. For larger scoped changes or inter team changes we advise writing a design document with behavior expectations. These documents are short references to avoid misunderstandings between all stakeholders in the implementation process and typically contain expected input and output parameters, REST, GRPC or GraphQL schemas or domain specific agreements such as storage decisions based on data access frequency.
+
+We avoid turning this process into unnecessary red tape by only involving the minimum amount of people and discussing the minimum of shared requirements, typically the engineer implementing the task, an engineer from the customer team, and optionally a tech lead. These conversations happen organically verbally or in team chats. We make it a habit of copying the information to a publicly available platform.
+
+### Implementation strategies
+
+Opensource
+Innersource
+Build it
+
+Ask innersource channel, stackoverflow, team, tech leads, tech community. Always prefere existing solutions. Problems are always more difficult than initially assumed.
+
+The implementing engineer utlimately pulls the trigger on the decision and is trusted to ultimately make the decision.
+
+Document the decision on whatever platform, or PR, reference the design doc.
+
+

--- a/docs/book/anatomy-of-a-code-change/change-decision.md
+++ b/docs/book/anatomy-of-a-code-change/change-decision.md
@@ -1,26 +1,17 @@
 # Game plan
 
-## Process within a code change
+## Design Documents
 
-product roadmap
-design docs
-PR reference
+After product features have been milled into sprint tasks and the tasks assigned to respective teams and engineers we start planning our implementation.
 
-After product features have been milled into sprint tasks and the tasks assigned to respective teams and engineers we start planning our implementation. For larger scoped changes or inter team changes we advise writing a design document with behavior expectations. These documents are short references to avoid misunderstandings between all stakeholders in the implementation process and typically contain expected input and output parameters, REST, GRPC or GraphQL schemas or domain specific agreements such as storage decisions based on data access frequency.
+For a majority of changes before diving straight into producing code we write a short design document with behavior expectations. These documents are short references to avoid misunderstandings between all stakeholders in the implementation process and typically contain expected input and output parameters, REST, GRPC or GraphQL schemas or domain specific agreements such as storage decisions based on data access frequency. Design documents are an imperative for larger scoped changes or inter team changes. 
 
-We avoid turning this process into unnecessary red tape by only involving the minimum amount of people and discussing the minimum of shared requirements, typically the engineer implementing the task, an engineer from the customer team, and optionally a tech lead. These conversations happen organically verbally or in team chats. We make it a habit of copying the information to a publicly available platform.
+We avoid turning this process into unnecessary red tape by only involving the minimum amount of people and discussing the minimum of shared requirements, typically the engineer implementing the task, an engineer from the customer team, and optionally a tech lead. These conversations happen organically verbally or in team chats. We make it a habit of copying the information to a publicly available platform, preferably in form of [Documenting Decisions]().
 
-### Implementation strategies
+### Existing solutions
 
-Opensource
-Innersource
-Build it
+Problems are always more difficult than initially assumed and we try to avoid re-writing code ourselves if a solution is available. Depending on our organization's open source policy we have a plethora of libraries and solutions available with permissive licensing.
 
-Ask innersource channel, stackoverflow, team, tech leads, tech community. Always prefere existing solutions. Problems are always more difficult than initially assumed.
+We make use of our innersource channels and internal tech community to search for code, documentation, or engineers who have encountered a similar problem and verify if their workings are applicable for our use case. Minor modifications to existing code repositories are preferable over constructing personal solutions. All code we introduce into our organization increases potential maintenance work and bugs.
 
-The implementing engineer utlimately pulls the trigger on the decision and is trusted to ultimately make the decision.
-
-Document the decision on whatever platform, or PR, reference the design doc.
-
-
-The implementing engineer has full trust on implementation decisions as long as the output matches the agreed upon design doc. Should implementation decisions turn out to be costly the design doc may be revisited with the stakeholders.
+Having covered our basis of existing implementations, we get to work. As the implementing engineer we have full trust on implementation decisions as long as the output matches the agreed upon design doc. If the documented requirements turn out to be costly during development, we revisit the design doc with the stakeholders.

--- a/docs/book/anatomy-of-a-code-change/change-decision.md
+++ b/docs/book/anatomy-of-a-code-change/change-decision.md
@@ -6,7 +6,7 @@ After product features have been milled into sprint tasks and the tasks assigned
 
 For a majority of changes before diving straight into producing code we write a short design document with behavior expectations. These documents are short references to avoid misunderstandings between all stakeholders in the implementation process and typically contain expected input and output parameters, REST, GRPC or GraphQL schemas or domain specific agreements such as storage decisions based on data access frequency. Design documents are an imperative for larger scoped changes or inter team changes. 
 
-We avoid turning this process into unnecessary red tape by only involving the minimum amount of people and discussing the minimum of shared requirements, typically the engineer implementing the task, an engineer from the customer team, and optionally a tech lead. These conversations happen organically verbally or in team chats. We make it a habit of copying the information to a publicly available platform, preferably in form of [Documenting Decisions]().
+We avoid turning this process into unnecessary red tape by involving the minimum amount of people necessary and strictly discussing the minimum of requirements for the task. The people involved can be limited to the engineer implementing the task, an engineer from the customer team, and optionally a tech lead. These conversations typically happen organically verbally or in team chats. We make it a habit of copying the information to a publicly available platform, preferably in form of [Documenting Decisions]().
 
 ## Existing solutions
 

--- a/docs/book/anatomy-of-a-code-change/change-decision.md
+++ b/docs/book/anatomy-of-a-code-change/change-decision.md
@@ -1,4 +1,4 @@
-# Feature decisions
+# Game plan
 
 ## Documenting decisions
 
@@ -54,3 +54,4 @@ The implementing engineer utlimately pulls the trigger on the decision and is tr
 Document the decision on whatever platform, or PR, reference the design doc.
 
 
+The implementing engineer has full trust on implementation decisions as long as the output matches the agreed upon design doc. Should implementation decisions turn out to be costly the design doc may be revisited with the stakeholders.

--- a/docs/book/anatomy-of-a-code-change/change-decision.md
+++ b/docs/book/anatomy-of-a-code-change/change-decision.md
@@ -1,36 +1,5 @@
 # Game plan
 
-## Documenting decisions
-
-Decision making is always speculative. Even with lots of data to rely on, we are predicting the future.
-
-https://www.redhat.com/architect/architecture-decision-records
-
-Decision Records
-
-Number
-Date
-People involved
-Title
-Context
-Decision
-Status
-Consequences
-
-Make a decision and document it. Easier for people to accept a conscious decision if the decision making process is available.
-Document the outcome of a decision, to track successful and unsuccessful patterns.
-
-Document, review, and iterate to ensure every participant understands the same thing. Take notes during meetings and share them with everybody to avoid misunderstandings.
-
-Keep all of the above decisions and progress visible and public to all stakeholders. Update continously. Maybe tooling that accumulates PR, issue comments, documentation, kanban boards, design docs etc.
-
-The more context we are able to give, the more transparent our decision is communicated. When evaluating the use of different libraries add the name and version of the libraries, benchmark numbers, ease of implementation, licensing, projected maintenance work etc.
-
-We clearly define the evaluation process that led to our final decision with all aspects. Every decision has advantages and drawbacks which need to be documented and unambiguously weighed against each other.
-
-Parameters change over time and decisions will be reevaluated.
-
-
 ## Process within a code change
 
 product roadmap

--- a/docs/book/anatomy-of-a-code-change/change-decision.md
+++ b/docs/book/anatomy-of-a-code-change/change-decision.md
@@ -1,17 +1,17 @@
-# Game plan
+# Planning implementations
+
+After product features have been milled into sprint tasks and the tasks assigned to respective teams and engineers, we start planning our implementation.
 
 ## Design Documents
-
-After product features have been milled into sprint tasks and the tasks assigned to respective teams and engineers we start planning our implementation.
 
 For a majority of changes before diving straight into producing code we write a short design document with behavior expectations. These documents are short references to avoid misunderstandings between all stakeholders in the implementation process and typically contain expected input and output parameters, REST, GRPC or GraphQL schemas or domain specific agreements such as storage decisions based on data access frequency. Design documents are an imperative for larger scoped changes or inter team changes. 
 
 We avoid turning this process into unnecessary red tape by only involving the minimum amount of people and discussing the minimum of shared requirements, typically the engineer implementing the task, an engineer from the customer team, and optionally a tech lead. These conversations happen organically verbally or in team chats. We make it a habit of copying the information to a publicly available platform, preferably in form of [Documenting Decisions]().
 
-### Existing solutions
+## Existing solutions
 
 Problems are always more difficult than initially assumed and we try to avoid re-writing code ourselves if a solution is available. Depending on our organization's open source policy we have a plethora of libraries and solutions available with permissive licensing.
 
-We make use of our innersource channels and internal tech community to search for code, documentation, or engineers who have encountered a similar problem and verify if their workings are applicable for our use case. Minor modifications to existing code repositories are preferable over constructing personal solutions. All code we introduce into our organization increases potential maintenance work and bugs.
+We make use of our [innersource](../anatomy-of-a-software-company/innersourcing.md) channels and internal tech community to search for code, documentation, or engineers who have encountered a similar problem and verify if their workings are applicable for our use case. Minor modifications to existing code repositories are preferable over constructing personal solutions. All code we introduce into our organization increases potential maintenance work and bugs.
 
 Having covered our basis of existing implementations, we get to work. As the implementing engineer we have full trust on implementation decisions as long as the output matches the agreed upon design doc. If the documented requirements turn out to be costly during development, we revisit the design doc with the stakeholders.

--- a/docs/book/anatomy-of-a-code-change/commit-messages.md
+++ b/docs/book/anatomy-of-a-code-change/commit-messages.md
@@ -1,5 +1,12 @@
 # Commit messages
 
+# keep commits inherntly consistent
+
+do not mix feauters and whitespace
+bugifxes and feautres
+fixes across different bugs
+commit frequently
+
 Writing commit messages sucks. Keeping messages short, concise and descriptive produces a significant cognitive load. The urge to type "Did things" or "Updated stuff" and be done with is completely natural.
 
 The use of well formed commit messages improves readability and traceability of the repository. Thankfully, there is a set of good practices that can help structure our commit messages and ease cognitive burden.

--- a/docs/book/anatomy-of-a-software-company/document-decisions.md
+++ b/docs/book/anatomy-of-a-software-company/document-decisions.md
@@ -1,0 +1,29 @@
+# Documenting decisions
+
+Decision making is always speculative. Even with lots of data to rely on, we are predicting the future.
+
+https://www.redhat.com/architect/architecture-decision-records
+
+Decision Records
+
+Number
+Date
+People involved
+Title
+Context
+Decision
+Status
+Consequences
+
+Make a decision and document it. Easier for people to accept a conscious decision if the decision making process is available.
+Document the outcome of a decision, to track successful and unsuccessful patterns.
+
+Document, review, and iterate to ensure every participant understands the same thing. Take notes during meetings and share them with everybody to avoid misunderstandings.
+
+Keep all of the above decisions and progress visible and public to all stakeholders. Update continously. Maybe tooling that accumulates PR, issue comments, documentation, kanban boards, design docs etc.
+
+The more context we are able to give, the more transparent our decision is communicated. When evaluating the use of different libraries add the name and version of the libraries, benchmark numbers, ease of implementation, licensing, projected maintenance work etc.
+
+We clearly define the evaluation process that led to our final decision with all aspects. Every decision has advantages and drawbacks which need to be documented and unambiguously weighed against each other.
+
+Parameters change over time and decisions will be reevaluated.

--- a/docs/book/anatomy-of-managing-a-team/planning-work.md
+++ b/docs/book/anatomy-of-managing-a-team/planning-work.md
@@ -8,3 +8,44 @@ Story points only work team internally. Story points cannot be directly used as 
 
 Plan for unexpected work
 
+
+## Who decides what
+
+Decision timelines and implications are driven from the top of the organizational hierarchy and turn more granular the further down the hierarchy we travel. C-level executives in combination with the organization's board tackle problems of the companies (and products) position within the market in the next 1-5 years, when and how to fund the development, how to scale and where to open new locations.
+
+With the broad vision documented, "VP"'s, "Head of"'s, and "Director"'s plan a road map for the next 6 - 24 months to set our organization up for success.
+
+Together with team leads the planned features are mapped to achievable milestones with the available resources for the next two quarters.
+
+Team leads plan sprints and 
+
+C-level executives and the organization's board documented the organizations vision and market position. VP's design the necessary product and internal milestones to steer the organization in the requested direction. In cooperation with team leads the milestones are mapped to available resources.
+
+With a dedicated road map in hand it is 
+
+1 year to 5 years
+
+Organization vision CEO/Board
+
+funding, location, remote work, scaling
+
+Technology vision CTO/Director of Engineering
+
+Product vision and compliance CPO Head of product
+
+Planning work
+
+6 months - 2 years
+
+Product - Feature
+Values, roadmap, strategie for market
+
+1 month - 6 months
+
+Management - Split and milestones
+Continous integration strategies of milestones and sprints
+
+2 days to 4 weeks
+
+Engineer - Details, libraries, implementation
+Implementation details, algorithms, open source libraries vs building

--- a/mkdocs-dist.yml
+++ b/mkdocs-dist.yml
@@ -86,6 +86,7 @@ nav:
     - The anatomy of a code change:
       - './book/anatomy-of-a-code-change/README.md'
       - CICD: './book/anatomy-of-a-code-change/cicd.md'
+      - Planning Implementations: './book/anatomy-of-a-code-change/change-decision.md'
 
   - Resources: 'resources.md'
   - Changelog: 'changelog.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
     - The anatomy of a code change:
       - './book/anatomy-of-a-code-change/README.md'
       - CICD: './book/anatomy-of-a-code-change/cicd.md'
-      - Who decides what?: './book/anatomy-of-a-code-change/change-decision.md'
+      - Planning Implementations: './book/anatomy-of-a-code-change/change-decision.md'
       - Trunk Based Development: './book/anatomy-of-a-code-change/tbd.md'
       - Commits: './book/anatomy-of-a-code-change/commit-messages.md'
       - Pull Requests: './book/anatomy-of-a-code-change/pr.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Communication Channels: './book/anatomy-of-a-software-company/communications-channels.md'
       - Team Interactions: './book/anatomy-of-a-software-company/team-interaction-modes.md'
       - Standardization: './book/anatomy-of-a-software-company/standards.md'
+      - Documenting Decisions: './book/anatomy-of-a-software-company/document-decisions.md'
       - Innersourcing: './book/anatomy-of-a-software-company/innersourcing.md'
       - Team Education and Training: './book/anatomy-of-a-software-company/team-education.md'
 


### PR DESCRIPTION
# Summary

This PR polishes the notes of previously named "Who decides what" and introduces the chapter as "Planning implementations" to the distributed book with the following headlines:

- Design Documents
- Prefering existing solutions

Further notes were added to chapters across all three sections of the book while editing the information within "Who decides what".

## Tasklist

- [x] Add new chapters to `mkdocs-dist.yaml`
